### PR TITLE
Add O3 dataset generation script and prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # AttnStyle
+
+This project explores automatic style transfer for artworks. To train and evaluate models, we first create a dataset that separates semantic content from artistic style. The steps below outline a simple procedure using the O3 API.
+
+## Dataset Generation Overview
+
+1. **Describe the painting**: For each WikiArt image, send a prompt asking for a description of the scene layout and objects while ignoring brushwork and color style.
+2. **Generate a neutral photo**: Use the returned description as input to a text-to-image model. Request a photorealistic DSLR-style rendition of the scene. This serves as the "content" image without the painting's style.
+3. **Store pairs**: Save the text description and generated photo alongside the original artwork. These pairs can train or evaluate style-transfer systems.
+
+See `data_generate/README.md` for a script and sample prompts.

--- a/data_generate/README.md
+++ b/data_generate/README.md
@@ -1,0 +1,49 @@
+# Data Generation with O3 API
+
+This folder contains a simple script to create content-style pairs from WikiArt images.
+The script assumes you have an API key for the O3 text-to-image service.
+
+## Usage
+
+```bash
+export O3_API_KEY=your_api_key
+# optional: export O3_ENDPOINT=https://api.o3.example/v1/generate
+python generate.py --input-dir path/to/wikiart --output-dir path/to/output
+```
+
+Each source image produces two files in the output directory:
+
+- `<name>_description.txt` – text describing the image content.
+- `<name>_photo.png` – a photorealistic rendition generated from the description.
+
+## Example Prompts
+
+You can experiment with different prompts by using the `--description-prompt`
+and `--generation-prompt` arguments. Here are a few examples:
+
+1. **Minimal layout**
+   - Description prompt:
+     `"List the main objects and where they appear in {image_path}. Ignore style."`
+   - Generation prompt:
+     `"Create a DSLR-style photograph depicting: {description}"`
+
+2. **Stage directions**
+   - Description prompt:
+     `"Write stage directions describing the scene in {image_path} without mentioning artistic style."`
+   - Generation prompt:
+     `"Render a realistic photo matching these stage directions: {description}"`
+
+3. **Spatial summary**
+   - Description prompt:
+     `"Summarize the spatial arrangement of subjects in {image_path}, omitting artistic brushwork."`
+   - Generation prompt:
+     `"Produce a detailed, photorealistic shot based on this summary: {description}"`
+
+4. **Object list**
+   - Description prompt:
+     `"Provide a concise list of objects in {image_path} with their relative positions."`
+   - Generation prompt:
+     `"Create a lifelike photograph from this list: {description}"`
+
+These variations can help determine which wording best removes artistic style
+while preserving the underlying scene.

--- a/data_generate/generate.py
+++ b/data_generate/generate.py
@@ -1,0 +1,59 @@
+import os
+import requests
+import argparse
+
+
+def call_o3_api(prompt: str, output_path: str, api_key: str, endpoint: str) -> None:
+    """Call the O3 API with a text prompt and save the resulting file.
+
+    This function assumes the API returns binary image data.
+    """
+    headers = {"Authorization": f"Bearer {api_key}"}
+    response = requests.post(endpoint, json={"prompt": prompt}, headers=headers)
+    response.raise_for_status()
+    with open(output_path, "wb") as f:
+        f.write(response.content)
+
+
+def generate_pair(image_path: str, output_dir: str, description_prompt: str, generation_prompt_template: str,
+                   api_key: str, endpoint: str) -> None:
+    """Generate a description and a photorealistic image from an artwork."""
+    basename = os.path.splitext(os.path.basename(image_path))[0]
+    desc_prompt = description_prompt.format(image_path=image_path)
+    # First call: get textual description
+    desc_output = os.path.join(output_dir, f"{basename}_description.txt")
+    headers = {"Authorization": f"Bearer {api_key}"}
+    resp = requests.post(endpoint, json={"prompt": desc_prompt}, headers=headers)
+    resp.raise_for_status()
+    description = resp.json().get("text", "")
+    with open(desc_output, "w") as f:
+        f.write(description)
+
+    # Second call: generate photo-realistic image
+    final_prompt = generation_prompt_template.format(description=description)
+    img_output = os.path.join(output_dir, f"{basename}_photo.png")
+    call_o3_api(final_prompt, img_output, api_key, endpoint)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate content-style pairs using the O3 API")
+    parser.add_argument("--input-dir", required=True, help="Directory of source artwork images")
+    parser.add_argument("--output-dir", required=True, help="Directory to write generated files")
+    parser.add_argument("--endpoint", default=os.environ.get("O3_ENDPOINT", "https://api.o3.example/v1/generate"),
+                        help="O3 API endpoint")
+    parser.add_argument("--description-prompt", default="Describe the layout and objects in {image_path}, ignoring artistic style.",
+                        help="Prompt template for obtaining descriptions")
+    parser.add_argument("--generation-prompt", default="Generate a photorealistic DSLR-style image based on: {description}",
+                        help="Prompt template for creating images")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("O3_API_KEY")
+    if not api_key:
+        raise RuntimeError("O3_API_KEY environment variable not set")
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    for fname in os.listdir(args.input_dir):
+        if not fname.lower().endswith((".png", ".jpg", ".jpeg")):
+            continue
+        generate_pair(os.path.join(args.input_dir, fname), args.output_dir, args.description_prompt,
+                      args.generation_prompt, api_key, args.endpoint)


### PR DESCRIPTION
## Summary
- document how to generate a dataset for style transfer
- add `data_generate/` folder with O3 API script
- supply multiple prompt examples

## Testing
- `python -m py_compile data_generate/generate.py`
- `pytest -q` *(fails: command not found)*